### PR TITLE
WIP: Add sources to the provider

### DIFF
--- a/src/components/DataProvider.js
+++ b/src/components/DataProvider.js
@@ -6,10 +6,11 @@ class DataProvider extends Component {
   constructor(props, context) {
     super(props, context)
     this.dataStore = props.dataStore
+    this.sources = props.sources
   }
 
   getChildContext() {
-    return {dataStore: this.dataStore}
+    return {dataStore: this.dataStore, sources: this.sources}
   }
 
   render() {
@@ -19,11 +20,13 @@ class DataProvider extends Component {
 
 DataProvider.propTypes = {
   dataStore: dataStoreShape.isRequired,
+  sources: PropTypes.object,
   children: PropTypes.element.isRequired,
 }
 
 DataProvider.childContextTypes = {
   dataStore: dataStoreShape.isRequired,
+  sources: PropTypes.object,
 }
 
 export default DataProvider

--- a/src/components/withData.js
+++ b/src/components/withData.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import {Component, createElement} from "react"
 import dataStoreShape from "../utils/dataStoreShape"
 import shallowEqual from "../utils/shallowEqual"

--- a/src/components/withData.js
+++ b/src/components/withData.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import {Component, createElement} from "react"
 import dataStoreShape from "../utils/dataStoreShape"
 import shallowEqual from "../utils/shallowEqual"
@@ -34,6 +35,7 @@ export default function withData(mapRecordsToProps, mergeProps) {
       constructor(props, context) {
         super(props, context)
         this.dataStore = props.dataStore || context.dataStore
+        this.sources = props.sources || context.sources
 
         if (!this.dataStore) {
           throw new Error(
@@ -82,11 +84,13 @@ export default function withData(mapRecordsToProps, mergeProps) {
         return recordProps
       }
 
-      getConvenienceProps = (dataStore) => {
+      getConvenienceProps = (dataStore, sources) => {
         if (!this.convenienceProps) {
           this.convenienceProps = {
             queryStore: (...args) => dataStore.query(...args),
             updateStore: (...args) => dataStore.update(...args),
+            dataStore,
+            sources,
           }
         }
 
@@ -151,7 +155,7 @@ export default function withData(mapRecordsToProps, mergeProps) {
         if (this.recordProps === null) {
           // Initial run
           nextRecordProps = {
-            ...this.getConvenienceProps(this.dataStore),
+            ...this.getConvenienceProps(this.dataStore, this.sources),
             ...this.computeAllRecordProps(this.dataStore, this.props)
           }
         } else if (this.haveOwnPropsChanged && this.doRecordPropsDependOnOwnProps) {
@@ -347,9 +351,11 @@ export default function withData(mapRecordsToProps, mergeProps) {
     WithData.WrappedComponent = WrappedComponent
     WithData.contextTypes = {
       dataStore: dataStoreShape,
+      sources: PropTypes.object,
     }
     WithData.propTypes = {
       dataStore: dataStoreShape,
+      sources: PropTypes.object,
     }
 
     return hoistStatics(WithData, WrappedComponent)


### PR DESCRIPTION
this PR supercedes the provider changes to: https://github.com/exivity/react-orbitjs/pull/16/files

The reason for the change is just to be able to have access to the remote source. (or really any source, since the dataStore doesn't give you access to the sources afaik)