### PR TITLE
feat: pass in dataStore as convenience prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,8 @@
 import React, { ComponentClass, ComponentType } from 'react';
-import Store from '@orbit/store';
-import { QueryOrExpression, QueryBuilder, FindRecordTerm, FindRecordsTerm, FindRelatedRecordTerm, FindRelatedRecordsTerm } from '@orbit/data';
+import { QueryOrExpression, QueryBuilder, FindRecordTerm, FindRecordsTerm, FindRelatedRecordTerm, FindRelatedRecordsTerm, Source } from '@orbit/data';
 
 export interface DataProviderProps {
-  dataStore: Store;
+  dataStore: Source;
 }
 
 export type RecordsToProps<Keys extends string | number | symbol> = {
@@ -11,7 +10,7 @@ export type RecordsToProps<Keys extends string | number | symbol> = {
 }
 
 export interface WithData {
-  dataStore: Store;
+  dataStore: Source;
 }
 
 export type WithDataProps =

--- a/src/__tests__/withData.js
+++ b/src/__tests__/withData.js
@@ -221,6 +221,22 @@ test('withData passes non-existing record as empty array in findRecords', () => 
   )
 })
 
+test('withData passes dataStore', () => {
+  const Test = ({ dataStore }) => {
+    expect(dataStore).toBe(store)
+
+    return <span>test</span>
+  }
+
+  const TestWithData = withData()(Test)
+
+  renderer.create(
+    <DataProvider dataStore={store}>
+      <TestWithData />
+    </DataProvider>
+  )
+})
+
 test('withData passes queryStore', () => {
   const Test = ({ queryStore }) => {
     expect(typeof queryStore).toEqual('function')
@@ -1205,6 +1221,7 @@ test('[regression] withData passes convenience props in subsequent renders (with
   )
   testComponent = componentRenderer.root.findByType(Test)
 
+  expect(testComponent.props.dataStore).toBe(store)
   expect(typeof testComponent.props.queryStore).toEqual('function')
   expect(typeof testComponent.props.updateStore).toEqual('function')
 
@@ -1215,6 +1232,7 @@ test('[regression] withData passes convenience props in subsequent renders (with
   )
   testComponent = componentRenderer.root.findByType(Test)
 
+  expect(testComponent.props.dataStore).toBe(store)
   expect(typeof testComponent.props.queryStore).toEqual('function')
   expect(typeof testComponent.props.updateStore).toEqual('function')
 
@@ -1235,6 +1253,7 @@ test('[regression] withData passes convenience props in subsequent renders (with
   )
   testComponent = componentRenderer.root.findByType(Test)
 
+  expect(testComponent.props.dataStore).toBe(store)
   expect(typeof testComponent.props.queryStore).toEqual('function')
   expect(typeof testComponent.props.updateStore).toEqual('function')
 
@@ -1245,6 +1264,7 @@ test('[regression] withData passes convenience props in subsequent renders (with
   )
   testComponent = componentRenderer.root.findByType(Test)
 
+  expect(testComponent.props.dataStore).toBe(store)
   expect(typeof testComponent.props.queryStore).toEqual('function')
   expect(typeof testComponent.props.updateStore).toEqual('function')
 })

--- a/src/components/withData.js
+++ b/src/components/withData.js
@@ -117,6 +117,7 @@ export default function withData(mapRecordsToProps, mergeProps) {
       getConvenienceProps = dataStore => {
         if (!this.convenienceProps) {
           this.convenienceProps = {
+            dataStore,
             queryStore: (...args) => dataStore.query(...args),
             updateStore: (...args) => dataStore.update(...args)
           }


### PR DESCRIPTION
Adds dataStore (typed as an @orbit/data Source) to the convenience props, for convenient access to e.g. `store.cache`.