### PR TITLE
chore: update renovate config for semantic-release

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,15 @@
   ],
   "dependencyDashboard": false,
   "automerge": true,
-  "rangeStrategy": "update-lockfile"
+  "rangeStrategy": "update-lockfile",
+  "packageRules": [
+    {
+      "matchPackageNames": ["@semantic-release/changelog"],
+      "allowedVersions": "~5"
+    },
+    {
+      "matchPackageNames": ["@semantic-release/git"],
+      "allowedVersions": "~9"
+    }
+  ]
 }


### PR DESCRIPTION
@semantic-release/changelog and @semantic-release/git do not support node 12 anymore.

Revert this commit if we remove support for node 12