### PR TITLE
Change global object for UMD

### DIFF
--- a/webpack.bundle.config.js
+++ b/webpack.bundle.config.js
@@ -9,6 +9,7 @@ module.exports = {
     filename: "react-orbitjs.js",
     library: "ReactOrbitjs",
     libraryTarget: "umd",
+    globalObject: "this"
   },
   externals: [
     "react",


### PR DESCRIPTION
I was getting a failure mode of 

```
$ jest
 FAIL  __tests__/App.test.android.tsx
  ● Test suite failed to run

    ReferenceError: self is not defined

       7 | import Orbit from "@orbit/core";
    >  8 | import {DataProvider} from "react-orbitjs";
         | ^
```

running jest tests in an Expo project.

Per the [webpack docs](https://webpack.js.org/configuration/output/#outputglobalobject),

> When targeting a library, especially when libraryTarget is `umd`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to `this`